### PR TITLE
Fix issue with nested object inside check error message

### DIFF
--- a/app/bookkit/helper/uu5string-escape-helper.js
+++ b/app/bookkit/helper/uu5string-escape-helper.js
@@ -6,7 +6,12 @@ const stringifyToEscapedUu5StringObject = (object) => {
     return JSON.stringify(object, null, 4)?.replaceAll('"', '\\\\\\"');
 }
 
+const enterStringNestedObjects = (string) => {
+    return string.replaceAll('\\\\"', '\"');
+}
+
 module.exports = {
     escapeUu5StringArray,
-    stringifyToEscapedUu5StringObject
+    stringifyToEscapedUu5StringObject,
+    enterStringNestedObjects
 }

--- a/app/command/check/main/bookkit/visualization/template/dashboard-template.js
+++ b/app/command/check/main/bookkit/visualization/template/dashboard-template.js
@@ -1,3 +1,5 @@
+const { enterStringNestedObjects } = require("../../../../../../bookkit/helper/uu5string-escape-helper");
+
 const template = (table, chart) => {
     const [tableColumns, tableData] = table;
     const [chartSeries, chartData, tableChartColumns, tableChartData] = chart;
@@ -48,7 +50,7 @@ const template = (table, chart) => {
                                 >
                                     <Uu5TilesBricks.Table 
                                         columns='<uu5json/>${JSON.stringify(tableColumns)}'
-                                        data='<uu5json/>${JSON.stringify(tableData[group])}'
+                                        data='<uu5json/>${enterStringNestedObjects(JSON.stringify(tableData[group]))}'
                                     />
                                 </UU5.Bricks.Panel>
                             `).join("")}


### PR DESCRIPTION
The issue caused uu5String to be invalid in BK because of nested objects inside an error from the check command call.